### PR TITLE
Add Dependencies to mod.conf

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,1 +1,3 @@
 name = mywoodslopes
+depends = default
+optional_depends = moretrees, ethereal


### PR DESCRIPTION
Simply adds dependencies to `mod.conf` for newer servers.